### PR TITLE
added License and Label models

### DIFF
--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -517,34 +517,6 @@ class RelationshipType(AddressableHALResource):
     def __init__(self, api_resource):
         super(RelationshipType, self).__init__(api_resource)
 
-    def get_metadata_values(self, field):
-        """
-        Return metadata values as simple list of strings
-        @param field: DSpace field, eg. dc.creator
-        @return: list of strings
-        """
-        values = list()
-        if field in self.metadata:
-            values = self.metadata[field]
-        return values
-
-    def as_dict(self):
-        """
-        Return a dict representation of this Item, based on super with item-specific attributes added
-        @return: dict of Item for API use
-        """
-        dso_dict = super(Item, self).as_dict()
-        item_dict = {'inArchive': self.inArchive, 'discoverable': self.discoverable, 'withdrawn': self.withdrawn}
-        return {**dso_dict, **item_dict}
-
-    @classmethod
-    def from_dso(cls, dso: DSpaceObject):
-        # Create new Item and copy everything over from this dso
-        item = cls()
-        for key, value in dso.__dict__.items():
-            item.__dict__[key] = value
-        return item
-
 class License(AddressableHALResource):
     """
     Specific attributes and functions for licenses

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -528,8 +528,11 @@ class License(AddressableHALResource):
         self.definition = (api_resource or {}).get('definition')
         self.confirmation = (api_resource or {}).get('confirmation', 0)
         self.requiredInfo = (api_resource or {}).get('requiredInfo')
-        self.licenseLabel = Label((api_resource or {}).get('clarinLicenseLabel'))
-        self.extendedLicenseLabel = [Label(label) for label in (api_resource or {}).get('extendedClarinLicenseLabels', [])]
+        self.licenseLabel = Label(license_label_value) \
+            if (license_label_value := (api_resource or {}).get('clarinLicenseLabel')) \
+            else None
+        self.extendedLicenseLabel = [Label(label) for label in
+                                     (api_resource or {}).get('extendedClarinLicenseLabels', [])]
         self.bitstream = (api_resource or {}).get('bitstreams')
 
     def to_dict(self):

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -523,17 +523,17 @@ class License(AddressableHALResource):
     """
     def __init__(self, api_resource=None):
         super(License, self).__init__(api_resource)
+        api_resource = api_resource or {}
         self.type = 'clarinlicense'
-        self.name = (api_resource or {}).get('name')
-        self.definition = (api_resource or {}).get('definition')
-        self.confirmation = (api_resource or {}).get('confirmation', 0)
-        self.requiredInfo = (api_resource or {}).get('requiredInfo')
-        self.licenseLabel = Label(license_label_value) \
-            if (license_label_value := (api_resource or {}).get('clarinLicenseLabel')) \
-            else None
+        self.name = api_resource.get('name')
+        self.definition = api_resource.get('definition')
+        self.confirmation = api_resource.get('confirmation', 0)
+        self.requiredInfo = api_resource.get('requiredInfo')
+        license_label_value = api_resource.get('clarinLicenseLabel')
+        self.licenseLabel = Label(license_label_value) if license_label_value else None
         self.extendedLicenseLabel = [Label(label) for label in
-                                     (api_resource or {}).get('extendedClarinLicenseLabels', [])]
-        self.bitstream = (api_resource or {}).get('bitstreams')
+                                     api_resource.get('extendedClarinLicenseLabels', [])]
+        self.bitstream = api_resource.get('bitstreams')
 
     def to_dict(self):
         return {
@@ -556,11 +556,12 @@ class Label(AddressableHALResource):
         @param api_resource: API result object to use as initial data
         """
         super(Label, self).__init__(api_resource)
+        api_resource = api_resource or {}
         self.type = 'clarinlicenselabel'
-        self.label = (api_resource or {}).get('label')
-        self.title = (api_resource or {}).get('title')
-        self.icon = (api_resource or {}).get('icon')
-        self.extended = (api_resource or {}).get('extended', False)
+        self.label = api_resource.get('label')
+        self.title = api_resource.get('title')
+        self.icon = api_resource.get('icon')
+        self.extended = api_resource.get('extended', False)
 
     def to_dict(self):
         return {

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -524,14 +524,13 @@ class License(AddressableHALResource):
     def __init__(self, api_resource=None):
         super(License, self).__init__(api_resource)
         self.type = 'clarinlicense'
-        if api_resource:
-            self.name = api_resource.get('name')
-            self.definition = api_resource.get('definition')
-            self.confirmation = api_resource.get('confirmation', 0)
-            self.requiredInfo = api_resource.get('requiredInfo')
-            self.licenseLabel = Label(api_resource.get('clarinLicenseLabel'))
-            self.extendedLicenseLabel = [Label(label) for label in api_resource.get('extendedClarinLicenseLabels', [])]
-            self.bitstream = api_resource.get('bitstreams')
+        self.name = (api_resource or {}).get('name')
+        self.definition = (api_resource or {}).get('definition')
+        self.confirmation = (api_resource or {}).get('confirmation', 0)
+        self.requiredInfo = (api_resource or {}).get('requiredInfo')
+        self.licenseLabel = Label((api_resource or {}).get('clarinLicenseLabel'))
+        self.extendedLicenseLabel = [Label(label) for label in (api_resource or {}).get('extendedClarinLicenseLabels', [])]
+        self.bitstream = (api_resource or {}).get('bitstreams')
 
     def to_dict(self):
         return {
@@ -555,11 +554,10 @@ class Label(AddressableHALResource):
         """
         super(Label, self).__init__(api_resource)
         self.type = 'clarinlicenselabel'
-        if api_resource:
-            self.label = api_resource.get('label')
-            self.title = api_resource.get('title')
-            self.icon = api_resource.get('icon')
-            self.extended = api_resource.get('extended', False)
+        self.label = (api_resource or {}).get('label')
+        self.title = (api_resource or {}).get('title')
+        self.icon = (api_resource or {}).get('icon')
+        self.extended = (api_resource or {}).get('extended', False)
 
     def to_dict(self):
         return {

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -521,27 +521,17 @@ class License(AddressableHALResource):
     """
     Specific attributes and functions for licenses
     """
-    type = 'clarinlicense'
-    name = None
-    definition = None
-    confirmation = 0
-    requiredInfo = None
-    licenseLabel = None
-    extendedLicenseLabel = []
-    bitstream = None
-
     def __init__(self, api_resource=None):
         super(License, self).__init__(api_resource)
-
-        if api_resource is not None:
-            self.type = 'clarinlicense'
-            self.name = api_resource['name'] if 'name' in api_resource else None
-            self.definition = api_resource['definition'] if 'definition' in api_resource else None
-            self.confirmation = api_resource['confirmation'] if 'confirmation' in api_resource else 0
-            self.requiredInfo = api_resource['requiredInfo'] if 'requiredInfo' in api_resource else None
-            self.licenseLabel = Label(api_resource['clarinLicenseLabel']) if 'clarinLicenseLabel' in api_resource else None
+        self.type = 'clarinlicense'
+        if api_resource:
+            self.name = api_resource.get('name')
+            self.definition = api_resource.get('definition')
+            self.confirmation = api_resource.get('confirmation', 0)
+            self.requiredInfo = api_resource.get('requiredInfo')
+            self.licenseLabel = Label(api_resource.get('clarinLicenseLabel'))
             self.extendedLicenseLabel = [Label(label) for label in api_resource.get('extendedClarinLicenseLabels', [])]
-            self.bitstream = api_resource['bitstreams'] if 'bitstreams' in api_resource else None
+            self.bitstream = api_resource.get('bitstreams')
 
     def to_dict(self):
         return {
@@ -558,25 +548,18 @@ class Label(AddressableHALResource):
     """
     Specific attributes and functions for licenses
     """
-    type = 'clarinlabel'
-    label = None
-    title = None
-    icon = None
-    extended = False
-
     def __init__(self, api_resource=None):
         """
         Default constructor. Call DSpaceObject init then set label-specific attributes
         @param api_resource: API result object to use as initial data
         """
         super(Label, self).__init__(api_resource)
-
-        if api_resource is not None:
-            self.type = 'clarinlicenselabel'
-            self.label = api_resource['label'] if 'label' in api_resource else None
-            self.title = api_resource['title'] if 'title' in api_resource else None
-            self.icon = api_resource['icon'] if 'icon' in api_resource else None
-            self.extended = api_resource['extended'] if 'extended' in api_resource else None
+        self.type = 'clarinlicenselabel'
+        if api_resource:
+            self.label = api_resource.get('label')
+            self.title = api_resource.get('title')
+            self.icon = api_resource.get('icon')
+            self.extended = api_resource.get('extended', False)
 
     def to_dict(self):
         return {


### PR DESCRIPTION
## Problem description
After the vanilla import, the tables containing licenses are empty because there were no licenses beforehand.

## Analysis
Fetch licenses, labels, and extended mappings from the database where licenses already exist. Filter them based on the definitions that are not required, and import them into vanilla DSpace where they are missing.
Added models for better work with database license fetch.