### PR TITLE
test for access to user-metadata and user-allowance endpoints

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -897,7 +897,7 @@ class DSpaceClient:
 
     def get_item_by_handle(self, handle):
         """
-        Get items based on handle.
+        Get item based on handle.
         """
         if handle is None:
             return None

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1197,9 +1197,7 @@ class DSpaceClient:
             data = parse_json(response)
             allowances = data.get('_embedded', {}).get('clarinlruallowances')
             if allowances:
-                _logger.info(f"Fetched {len(allowances)} CLARIN LRU allowances.")
                 return allowances
-            _logger.warning("No CLARIN LRU allowances found.")
         except Exception as e:
             _logger.error(f"Error fetching CLARIN LRU allowances [{url}]: {e}")
         return None
@@ -1215,9 +1213,7 @@ class DSpaceClient:
             data = parse_json(response)
             allowances = data.get('_embedded', {}).get('clarinlruallowances')
             if allowances:
-                _logger.info(f"Found {len(allowances)} user allowance(s).")
                 return allowances
-            _logger.warning(f"No user allowances found for user: {user_uuid} and bitstream: {bitstream_uuid}")
         except Exception as e:
             _logger.error(f"Error fetching user allowances: {e}")
         return None
@@ -1236,9 +1232,7 @@ class DSpaceClient:
         try:
             response = self.api_post(url, json=metadata_payload, params=params)
             if response.status_code == 200:
-                _logger.info(f"User metadata access managed for bitstream: {bitstream_uuid}")
                 return True
-            _logger.warning(f"Failed to manage user metadata: {response.status_code}")
         except Exception as e:
             _logger.error(f"Error managing user metadata: {e}")
         return False
@@ -1253,7 +1247,6 @@ class DSpaceClient:
         try:
             response = self.api_get(url, params=params)
             user_data = parse_json(response)
-            _logger.info(f"User fetched by email: {email}")
             return User(user_data)
         except Exception as e:
             _logger.error(f"Error retrieving user by email {email}: {e}")

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -704,7 +704,6 @@ class DSpaceClient:
             logging.error(f'Error creating bitstream: {r.status_code}: {r.text}')
             return None
 
-
     def download_bitstream(self, uuid=None):
         """
         Download bitstream and return full response object including headers, and content

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1201,7 +1201,7 @@ class DSpaceClient:
             logging.error(f"Error fetching CLARIN LRU allowances [{url}]: {e}")
         return None
 
-    def get_clarinlruallowances_by_bitstreama_and_user(self, bitstream_uuid, user_uuid):
+    def get_clarinlruallowances_by_bitstream_and_user(self, bitstream_uuid, user_uuid):
         """
         Fetch user allowances for a specific bitstream and user.
         """
@@ -1260,7 +1260,7 @@ class DSpaceClient:
 
     def get_http_status(self, url):
         """
-        Check the HTTP status code of a URL.
+        Get the HTTP status code of a URL.
         """
         if not url:
             logging.warning("Provided URL is not defined.")
@@ -1274,9 +1274,9 @@ class DSpaceClient:
             return None
 
 
-    def fetch_bundle(self, bundle_reference):
+    def get_bundle(self, bundle_reference):
         """
-        Fetch a bundle either by UUID or URL.
+        Get a bundle either by UUID or URL.
         """
         if not bundle_reference:
             logging.warning("No bundle reference provided.")
@@ -1287,16 +1287,17 @@ class DSpaceClient:
         try:
             response = self.api_get(url)
             data = parse_json(response)
-            bundle = data.get('_embedded', {}).get('bundles', [{}])[0]
+            bundles = data.get('_embedded', {}).get('bundles', [])
+            bundle = bundles[0] if bundles else {}
             logging.info(f"Bundle retrieved: {bundle.get('uuid', 'unknown')}")
             return bundle
         except Exception as e:
-            logging.error(f"Error fetching bundle: {e}")
+            logging.error(f"Error getting bundle: {e}")
             return None
 
-    def fetch_bitstreams(self, bitstream_reference):
+    def get_bitstream(self, bitstream_reference):
         """
-        Fetch bitstreams either by UUID or direct URL.
+        Get bitstream either by UUID or direct URL.
         """
         if not bitstream_reference:
             logging.warning("No bitstream reference provided.")
@@ -1308,10 +1309,11 @@ class DSpaceClient:
             response = self.api_get(url)
             data = parse_json(response)
             bitstreams = data.get('_embedded', {}).get('bitstreams', [])
-            logging.info(f"Fetched {len(bitstreams)} bitstream(s).")
-            return bitstreams
+            bitstream = bitstreams[0] if bitstreams else {}
+            logging.info(f"Bitstream retrieved: {bitstream.get('uuid', 'unknown')}")
+            return bitstream
         except Exception as e:
-            logging.error(f"Error fetching bitstreams: {e}")
+            logging.error(f"Error getting bitstream: {e}")
             return None
 
 


### PR DESCRIPTION
### 4 tested scenarios:
1. Anonymous access to existing user metadata and user allowance → forbidden
2. Admin access to existing user metadata and user allowance → allowed
3. Regular user accessing another user's metadata and user allowance → forbidden
3. Regular user accessing their own metadata and user allowance → allowed

### Notes:
- For scenario 4, an item with the following handle must exist: handle = 'http://hdl.handle.net/11234/1-4930'
- In scenario 4, if the user allowance is created, it is not deleted from the database after the test.
When the test runs again, it checks whether the data already exists.

**Connected with:** https://github.com/dataquest-dev/dspace-rest-test/pull/27