### PR TITLE
Updated `api_get` methods - try reauthenticate when 401 or 403

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -182,7 +182,7 @@ class DSpaceClient:
             headers = self.request_headers
         r = self.session.get(url, params=params, data=data, headers=headers)
         self.update_token(r)
-        
+
         if r.status_code == 403:
             # 403 Forbidden
             # If we had a CSRF failure, retry the request with the updated token
@@ -202,10 +202,10 @@ class DSpaceClient:
             r_json = parse_json(r)
             if r_json and 'message' in r_json and 'Authentication is required' in r_json['message']:
                 if retry:
-                    logging.error(
+                    _logger.error(
                         'API Post: Already retried... something must be wrong')
                 else:
-                    logging.debug("API Post: Retrying request with updated CSRF token")
+                    _logger.debug("API Post: Retrying request with updated CSRF token")
                     # try to authenticate
                     self.authenticate()
                     # Try to authenticate and repeat the request 3 times -
@@ -246,10 +246,10 @@ class DSpaceClient:
             r_json = parse_json(r)
             if r_json and 'message' in r_json and 'Authentication is required' in r_json['message']:
                 if retry:
-                    logging.error(
+                    _logger.error(
                         'API Post: Already retried... something must be wrong')
                 else:
-                    logging.debug("API Post: Retrying request with updated CSRF token")
+                    _logger.debug("API Post: Retrying request with updated CSRF token")
                     # try to authenticate
                     self.authenticate()
                     # Try to authenticate and repeat the request 3 times -
@@ -289,10 +289,10 @@ class DSpaceClient:
             r_json = parse_json(r)
             if 'message' in r_json and 'Authentication is required' in r_json['message']:
                 if retry:
-                    logging.error(
+                    _logger.error(
                         'API Post: Already retried... something must be wrong')
                 else:
-                    logging.debug("API Post: Retrying request with updated CSRF token")
+                    _logger.debug("API Post: Retrying request with updated CSRF token")
                     # try to authenticate
                     self.authenticate()
                     # Try to authenticate and repeat the request 3 times -
@@ -348,14 +348,14 @@ class DSpaceClient:
             # If we had a CSRF failure, retry the request with the updated token
             # After speaking in #dev it seems that these do need occasional refreshes but I suspect
             # it's happening too often for me, so check for accidentally triggering it
-            logging.debug(r.text)
+            _logger.debug(r.text)
             # Parse response
             r_json = parse_json(r)
             if r_json and 'message' in r_json and 'CSRF token' in r_json['message']:
                 if retry:
-                    logging.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
+                    _logger.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
                 else:
-                    logging.debug("Retrying request with updated CSRF token")
+                    _logger.debug("Retrying request with updated CSRF token")
                     return self.api_put_uri(url, params=params, uri_list=uri_list, retry=True)
 
         return r
@@ -400,15 +400,15 @@ class DSpaceClient:
         @see https://github.com/DSpace/RestContract/blob/main/metadata-patch.md
         """
         if url is None:
-            logging.error('Missing required URL argument')
+            _logger.error('Missing required URL argument')
             return None
         if path is None:
-            logging.error('Need valid path eg. /withdrawn or /metadata/dc.title/0/language')
+            _logger.error('Need valid path eg. /withdrawn or /metadata/dc.title/0/language')
             return None
         if (operation == self.PatchOperation.ADD or operation == self.PatchOperation.REPLACE
                 or operation == self.PatchOperation.MOVE) and value is None:
             # missing value required for add/replace/move operations
-            logging.error('Missing required "value" argument for add/replace/move operations')
+            _logger.error('Missing required "value" argument for add/replace/move operations')
             return None
 
         # compile patch data
@@ -557,7 +557,7 @@ class DSpaceClient:
             return None
         dso_type = type(dso)
         if not isinstance(dso, SimpleDSpaceObject):
-            logging.error('Only SimpleDSpaceObject types (eg Item, Collection, Community) '
+            _logger.error('Only SimpleDSpaceObject types (eg Item, Collection, Community) '
                   'are supported by generic update_dso PUT.')
             return dso
         try:
@@ -604,11 +604,11 @@ class DSpaceClient:
         """
         if dso is None:
             if url is None:
-                logging.error('Need a DSO or a URL to delete')
+                _logger.error('Need a DSO or a URL to delete')
                 return None
         else:
             if not isinstance(dso, SimpleDSpaceObject):
-                logging.error('Only SimpleDSpaceObject types (eg Item, Collection, Community, EPerson) '
+                _logger.error('Only SimpleDSpaceObject types (eg Item, Collection, Community, EPerson) '
                       'are supported by generic update_dso PUT.')
                 return dso
             # Get self URI from HAL links
@@ -1036,7 +1036,7 @@ class DSpaceClient:
         """
         if dso is None or field is None or place is None or not isinstance(dso, DSpaceObject):
             # TODO: separate these tests, and add better error handling
-            logging.error('Invalid or missing DSpace object, field or value string')
+            _logger.error('Invalid or missing DSpace object, field or value string')
             return self
         dso_type = type(dso)
 
@@ -1070,7 +1070,7 @@ class DSpaceClient:
 
     def delete_user(self, user):
         if not isinstance(user, User):
-            logging.error('Must be a valid user')
+            _logger.error('Must be a valid user')
             return None
         return self.delete_dso(user)
 

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -181,7 +181,8 @@ class DSpaceClient:
         if headers is None:
             headers = self.request_headers
         r = self.session.get(url, params=params, data=data, headers=headers)
-
+        self.update_token(r)
+        
         if r.status_code == 403:
             # 403 Forbidden
             # If we had a CSRF failure, retry the request with the updated token
@@ -211,7 +212,6 @@ class DSpaceClient:
                     # if it won't happen log error
                     return self.api_get(url, params=params, data=data, headers=headers, retry=True)
 
-        self.update_token(r)
         return r
 
     def api_post(self, url, params, json, retry=False):

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -261,7 +261,6 @@ class DSpaceClient:
         @param data:    Data in text/plain format to send as POST body
         @param url:     DSpace REST API URL
         @param params:  Any parameters to include (eg ?parent=abbc-....)
-        @param uri_list: One or more URIs referencing objects
         @param retry:   Has this method already been retried? Used if we need to refresh XSRF.
         @return:        Response from API
         """

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -199,7 +199,7 @@ class DSpaceClient:
         # solution copied from the past
         elif r.status_code == 401:
             r_json = parse_json(r)
-            if 'message' in r_json and 'Authentication is required' in r_json['message']:
+            if r_json and 'message' in r_json and 'Authentication is required' in r_json['message']:
                 if retry:
                     logging.error(
                         'API Post: Already retried... something must be wrong')
@@ -244,7 +244,7 @@ class DSpaceClient:
         # solution copied from the past
         elif r.status_code == 401:
             r_json = parse_json(r)
-            if 'message' in r_json and 'Authentication is required' in r_json['message']:
+            if r_json and 'message' in r_json and 'Authentication is required' in r_json['message']:
                 if retry:
                     logging.error(
                         'API Post: Already retried... something must be wrong')
@@ -276,7 +276,7 @@ class DSpaceClient:
             # After speaking in #dev it seems that these do need occasional refreshes but I suspect
             # it's happening too often for me, so check for accidentally triggering it
             r_json = r.json()
-            if 'message' in r_json and 'CSRF token' in r_json['message']:
+            if r_json and 'message' in r_json and 'CSRF token' in r_json['message']:
                 if retry:
                     _logger.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
                 else:
@@ -322,7 +322,7 @@ class DSpaceClient:
             _logger.debug(r.text)
             # Parse response
             r_json = parse_json(r)
-            if 'message' in r_json and 'CSRF token' in r_json['message']:
+            if r_json and 'message' in r_json and 'CSRF token' in r_json['message']:
                 if retry:
                     _logger.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
                 else:
@@ -351,7 +351,7 @@ class DSpaceClient:
             logging.debug(r.text)
             # Parse response
             r_json = parse_json(r)
-            if 'message' in r_json and 'CSRF token' in r_json['message']:
+            if r_json and 'message' in r_json and 'CSRF token' in r_json['message']:
                 if retry:
                     logging.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
                 else:
@@ -380,7 +380,7 @@ class DSpaceClient:
             _logger.debug(r.text)
             # Parse response
             r_json = parse_json(r)
-            if 'message' in r_json and 'CSRF token' in r_json['message']:
+            if r_json and 'message' in r_json and 'CSRF token' in r_json['message']:
                 if retry:
                     _logger.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
                 else:
@@ -434,7 +434,7 @@ class DSpaceClient:
             # it's happening too often for me, so check for accidentally triggering it
             _logger.debug(r.text)
             r_json = parse_json(r)
-            if 'message' in r_json and 'CSRF token' in r_json['message']:
+            if r_json and 'message' in r_json and 'CSRF token' in r_json['message']:
                 if retry:
                     _logger.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
                 else:

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -203,9 +203,9 @@ class DSpaceClient:
             if r_json and 'message' in r_json and 'Authentication is required' in r_json['message']:
                 if retry:
                     _logger.error(
-                        'API Post: Already retried... something must be wrong')
+                        'API Get: Already retried... something must be wrong')
                 else:
-                    _logger.debug("API Post: Retrying request with updated CSRF token")
+                    _logger.debug("API Get: Retrying request with updated CSRF token")
                     # try to authenticate
                     self.authenticate()
                     # Try to authenticate and repeat the request 3 times -


### PR DESCRIPTION
Related with issue: https://github.com/dataquest-dev/dspace-customers/issues/253