### PR TITLE
fix: upstream bugfixes and proxy support backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pypackages__/
 env/
 venv/
 .idea/
+upstream_ref/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ __pypackages__/
 env/
 venv/
 .idea/
-upstream_ref/

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -16,11 +16,12 @@ better abstracting and handling of HAL-like API responses, plus just all the oth
 """
 import json
 import logging
+import os
+from uuid import UUID
 
 import requests
 from requests import Request
-import os
-from uuid import UUID
+
 from .models import *
 
 __all__ = ['DSpaceClient']
@@ -37,9 +38,13 @@ def parse_json(response):
     """
     response_json = None
     try:
-        response_json = response.json()
+        if response is not None:
+            response_json = response.json()
     except ValueError as err:
-        _logger.error(f'Error parsing response JSON: {err}. Body text: {response.text}')
+        if response is not None:
+            _logger.error(f'Error parsing response JSON: {err}. Body text: {response.text}')
+        else:
+            _logger.error(f'Error parsing response JSON: {err}. Response is None')
     return response_json
 
 
@@ -73,6 +78,8 @@ class DSpaceClient:
     if 'USER_AGENT' in os.environ:
         USER_AGENT = os.environ['USER_AGENT']
     verbose = False
+    ITER_PAGE_SIZE = 20
+    PROXY_DICT = dict(http=os.environ["PROXY_URL"],https=os.environ["PROXY_URL"]) if "PROXY_URL" in os.environ else dict()
 
     # Simple enum for patch operation types
     class PatchOperation:
@@ -82,7 +89,7 @@ class DSpaceClient:
         MOVE = 'move'
 
     def __init__(self, api_endpoint=API_ENDPOINT, username=USERNAME, password=PASSWORD, solr_endpoint=SOLR_ENDPOINT,
-                 solr_auth=SOLR_AUTH, fake_user_agent=False):
+                 solr_auth=SOLR_AUTH, fake_user_agent=False, proxies=PROXY_DICT):
         """
         Accept optional API endpoint, username, password arguments using the OS environment variables as defaults
         :param api_endpoint:    base path to DSpace REST API, eg. http://localhost:8080/server/api
@@ -95,6 +102,7 @@ class DSpaceClient:
         self.USERNAME = username
         self.PASSWORD = password
         self.SOLR_ENDPOINT = solr_endpoint
+        self.proxies = proxies
         self.solr = None
         self._last_err = None
         try:
@@ -128,7 +136,8 @@ class DSpaceClient:
         # Set headers for requests made during authentication
         # Get and update CSRF token
         r = self.session.post(self.LOGIN_URL, data={'user': self.USERNAME, 'password': self.PASSWORD},
-                              headers=self.auth_request_headers)
+                              headers=self.auth_request_headers,
+                              proxies=self.proxies)
         self.update_token(r)
 
         if r.status_code == 403:
@@ -154,7 +163,8 @@ class DSpaceClient:
             self.session.headers.update({'Authorization': r.headers.get('Authorization')})
 
         # Get and check authentication status
-        r = self.session.get(f'{self.API_ENDPOINT}/authn/status', headers=self.request_headers)
+        r = self.session.get(f'{self.API_ENDPOINT}/authn/status', headers=self.request_headers,
+                             proxies=self.proxies)
         if r.status_code == 200:
             r_json = parse_json(r)
             if 'authenticated' in r_json and r_json['authenticated'] is True:
@@ -203,7 +213,8 @@ class DSpaceClient:
         self._last_err = None
         if headers is None:
             headers = self.request_headers
-        r = self.session.get(url, params=params, data=data, headers=headers)
+        r = self.session.get(url, params=params, data=data, headers=headers,
+                             proxies=self.proxies)
         self.update_token(r)
         return r
 
@@ -218,7 +229,8 @@ class DSpaceClient:
         @return:        Response from API
         """
         self._last_err = None
-        r = self.session.post(url, json=json, params=params, headers=self.request_headers)
+        r = self.session.post(url, json=json, params=params, headers=self.request_headers,
+                              proxies=self.proxies)
         self.update_token(r)
 
         if r.status_code == 403:
@@ -262,7 +274,8 @@ class DSpaceClient:
         @return:        Response from API
         """
         self._last_err = None
-        r = self.session.post(url, data=uri_list, params=params, headers=self.list_request_headers)
+        r = self.session.post(url, data=uri_list, params=params, headers=self.list_request_headers,
+                              proxies=self.proxies)
         self.update_token(r)
 
         if r.status_code == 403:
@@ -291,7 +304,8 @@ class DSpaceClient:
         @return:        Response from API
         """
         self._last_err = None
-        r = self.session.put(url, params=params, json=json, headers=self.request_headers)
+        r = self.session.put(url, params=params, json=json, headers=self.request_headers,
+                             proxies=self.proxies)
         self.update_token(r)
 
         if r.status_code == 403:
@@ -321,7 +335,8 @@ class DSpaceClient:
         @return:        Response from API
         """
         self._last_err = None
-        r = self.session.delete(url, params=params, headers=self.request_headers)
+        r = self.session.delete(url, params=params, headers=self.request_headers,
+                                proxies=self.proxies)
         self.update_token(r)
 
         if r.status_code == 403:
@@ -341,12 +356,13 @@ class DSpaceClient:
 
         return r
 
-    def api_patch(self, url, operation, path, value, retry=False):
+    def api_patch(self, url, operation, path, value, params=None, retry=False):
         """
         @param url: DSpace REST API URL
         @param operation: 'add', 'remove', 'replace', or 'move' (see PatchOperation enumeration)
         @param path: path to perform operation - eg, metadata, withdrawn, etc.
         @param value: new value for add or replace operations, or 'original' path for move operations
+        @param params:  Optional parameters
         @param retry:   Has this method already been retried? Used if we need to refresh XSRF.
         @return:
         @see https://github.com/DSpace/RestContract/blob/main/metadata-patch.md
@@ -377,7 +393,8 @@ class DSpaceClient:
 
         # set headers
         # perform patch request
-        r = self.session.patch(url, json=[data], headers=self.request_headers)
+        r = self.session.patch(url, json=[data], params=params, headers=self.request_headers,
+                               proxies=self.proxies)
         self.update_token(r)
 
         if r.status_code == 403:
@@ -392,7 +409,7 @@ class DSpaceClient:
                     _logger.warning(f'Too many retries updating token: {r.status_code}: {r.text}')
                 else:
                     _logger.debug("Retrying request with updated CSRF token")
-                    return self.api_patch(url, operation, path, value, True)
+                    return self.api_patch(url, operation, path, value, params, True)
         elif r.status_code == 200:
             # 200 Success
             _logger.info(f'successful patch update to {r.json()["type"]} {r.json()["id"]}')
@@ -727,7 +744,7 @@ class DSpaceClient:
         h.update({'Content-Encoding': 'gzip', 'User-Agent': self.USER_AGENT})
         req = Request('POST', url, data=payload, headers=h, files=files)
         prepared_req = self.session.prepare_request(req)
-        r = self.session.send(prepared_req)
+        r = self.session.send(prepared_req, proxies=self.proxies)
         if 'DSPACE-XSRF-TOKEN' in r.headers:
             t = r.headers['DSPACE-XSRF-TOKEN']
             _logger.debug('Updating token to ' + t)
@@ -922,7 +939,7 @@ class DSpaceClient:
         r = self.api_get(url, params=params)
         r_json = parse_json(response=r)
         if '_embedded' in r_json:
-            if 'collections' in r_json['_embedded']:
+            if 'items' in r_json['_embedded']:
                 for item_resource in r_json['_embedded']['items']:
                     items.append(Item(item_resource))
         elif 'uuid' in r_json:

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -37,6 +37,10 @@ class HALResource:
                 self.links = api_resource['_links'].copy()
             else:
                 self.links = {'self': {'href': None}}
+            if '_embedded' in api_resource:
+                self.embedded = api_resource['_embedded'].copy()
+            else:
+                self.embedded = {}
 
 class AddressableHALResource(HALResource):
     id = None
@@ -421,12 +425,12 @@ class User(SimpleDSpaceObject):
     Extends DSpaceObject to implement specific attributes and methods for users (aka. EPersons)
     """
     type = 'user'
-    name = None,
-    netid = None,
-    lastActive = None,
-    canLogIn = False,
-    email = None,
-    requireCertificate = False,
+    name = None
+    netid = None
+    lastActive = None
+    canLogIn = False
+    email = None
+    requireCertificate = False
     selfRegistered = False
 
     def __init__(self, api_resource=None):
@@ -473,11 +477,11 @@ class InProgressSubmission(AddressableHALResource):
         if 'lastModified' in api_resource:
             self.lastModified = api_resource['lastModified']
         if 'step' in api_resource:
-            self.step = api_resource['lastModified']
+            self.step = api_resource['step']
         if 'sections' in api_resource:
             self.sections = api_resource['sections'].copy()
         if 'type' in api_resource:
-            self.lastModified = api_resource['lastModified']
+            self.type = api_resource['type']
 
     def as_dict(self):
         parent_dict = super(InProgressSubmission, self).as_dict()
@@ -508,7 +512,7 @@ class EntityType(AddressableHALResource):
         if 'label' in api_resource:
             self.label = api_resource['label']
         if 'type' in api_resource:
-            self.label = api_resource['type']
+            self.type = api_resource['type']
 
 class RelationshipType(AddressableHALResource):
     """


### PR DESCRIPTION
## Summary

Backport critical bugfixes and improvements from [the-library-code/dspace-rest-python](https://github.com/the-library-code/dspace-rest-python) upstream (v0.1.14-v0.1.16) into our fork.

## Bug Fixes

### Critical

1. **User class trailing comma bug** (models.py) - Class-level field definitions like `name = None,` had trailing commas, silently creating **tuples** `(None,)` instead of `None`. This caused incorrect behavior in JSON serialization, comparisons (`user.name is None` -> `False`), and any downstream code assuming these are plain values. All 6 affected fields fixed.

2. **get_items() never returning results** (client.py) - Was checking `collections` in `r_json['_embedded']` instead of `items`, meaning this method **always returned an empty list** even when the API responded correctly.

3. **InProgressSubmission.__init__ double assignment bugs** (models.py) - Two bugs: `self.step` was assigned `api_resource['lastModified']` instead of `api_resource['step']`; when `type` was present, it overwrote `self.lastModified` with itself instead of setting `self.type`.

4. **EntityType.__init__ label overwrite** (models.py) - The `type` field was being assigned to `self.label`, destroying the correctly parsed label value. Fixed to assign to `self.type`.

### Improvements

5. **Proxy support for all HTTP methods** (client.py) - Added `PROXY_DICT` class variable (reads `PROXY_URL` env var), `proxies` parameter to `DSpaceClient.__init__()`, and `proxies=self.proxies` to all 7 HTTP methods: `authenticate`, `api_get`, `api_post`, `api_post_uri`, `api_put`, `api_delete`, `api_patch`.

6. **params parameter added to api_patch()** (client.py) - Upstream added `params=None` to `api_patch()` and passes it to `session.patch()`. Previously query parameters could not be passed during PATCH operations.

7. **embedded attribute on HALResource** (models.py) - All HAL resources now store `_embedded` data from API responses into `self.embedded`. Enables access to embedded sub-resources (e.g. `community.embedded['logo']`).

## API / Breaking Changes

| Change | Impact | Migration |
|--------|--------|-----------|
| `DSpaceClient.__init__()` has new `proxies` parameter | **Non-breaking** - defaults to `PROXY_DICT` (empty dict if no env var) | No action needed; pass `proxies={...}` to use |
| `api_patch()` has new `params` parameter | **Non-breaking** - defaults to `None` (same behavior as before) | No action needed |
| `HALResource` and subclasses now have `.embedded` attribute | **Non-breaking** - new attribute, defaults to `{}` | Can now access `dso.embedded['logo']` etc. |
| `User` class fields changed from tuples to proper types | **Potentially breaking** if code depended on buggy tuple values | Update `user.name == (None,)` to `user.name is None` |
| `get_items()` now actually returns items | **Behavior change** - previously always returned `[]` | Code that worked around the bug may need updating |
| `InProgressSubmission.step` now correctly populated | **Behavior change** - was previously set to `lastModified` | `.step` now gets the real value |
| `InProgressSubmission.type` now correctly populated | **Behavior change** - was previously always `None` | `.type` now gets the real value |
| `EntityType.type` no longer overwrites `.label` | **Behavior change** | `.label` now correct, `.type` now populated |

## Not Included

The following upstream additions were intentionally **not** included (new features, not bugfixes):

- `paginated` decorator and `*_iter` auto-paginating methods
- `parse_params` / `embeds` parameter throughout methods
- `create_item_version`, `create_resource_policy`, `resolve_identifier_to_dso` methods
- `BitstreamFormat`, `SearchResult` model classes
- `smart_open` S3 support in `create_bitstream`
- Migration from `setup.py` to `pyproject.toml`
- `search_objects` `configuration` parameter