### PR TITLE
fix(client): return empty bundles on 404 instead of crashing

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -475,6 +475,9 @@ class DSpaceClient:
         """
         r = self.api_get(url, params, None)
         if r.status_code != 200:
+            # record the failing response so callers can tell a 404 (the
+            # resource is gone) from a transient 5xx before we drop the body
+            self._last_err = r
             _logger.error(f'Error encountered fetching resource: {r.text}')
             return None
         # ValueError / JSON handling moved to static method
@@ -698,6 +701,12 @@ class DSpaceClient:
         if sort is not None:
             params['sort'] = sort
         r_json = self.fetch_resource(url, params=params)
+        if r_json is None and getattr(self._last_err, 'status_code', None) == 404:
+            # the item (or bundle) no longer exists - a deleted item simply has
+            # no bundles, which is a clean empty result, not a crash. any other
+            # failure falls through and still surfaces to the caller.
+            _logger.info(f'No bundles: resource not found (404) [{url}]')
+            return bundles
         try:
             if single_result:
                 bundles.append(Bundle(r_json))


### PR DESCRIPTION
## Problem

A bitstream export walks every item in the cached `dspace.all.json` and asks DSpace for each item's bundles. An item **deleted from the repository since the cache was built** answers `404`; `fetch_resource` then returns `None`, and `get_bundles` subscripted that `None`:

```
'NoneType' object is not subscriptable
```

— a scary `CRITICAL` line for what is really just "this item is gone".

## Fix

- `fetch_resource` now records the failing response on `self._last_err` before dropping the body, so callers can distinguish a gone resource (`404`) from a transient `5xx`.
- `get_bundles` treats a `404` as a **clean empty result** (a deleted item simply has no bundles) and returns `[]`.
- **Any other failure still falls through** and surfaces to the caller, so a transient `5xx` keeps its retry and is counted as a failure rather than silently recorded as an item with no files.

9 lines, one file (`dspace_rest_client/client.py`). `_last_err` is already initialised to `None` in `__init__`, so the `getattr(...)` guard is safe.

## Tests

Covered by `tests/test_get_bundles_missing_item.py` in the consumer repo (DSpace-ISstag-integration):
- `404` → `get_bundles` returns `[]` (no crash)
- `503` → still surfaces (caller retries / counts the failure)

Both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)