### PR TITLE
merge: bring CLARIN branch (main) into dtq

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -897,7 +897,7 @@ class DSpaceClient:
 
     def get_item_by_handle(self, handle):
         """
-        Get items based on handle.
+        Get item based on handle.
         """
         if handle is None:
             return None

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1197,9 +1197,7 @@ class DSpaceClient:
             data = parse_json(response)
             allowances = data.get('_embedded', {}).get('clarinlruallowances')
             if allowances:
-                _logger.info(f"Fetched {len(allowances)} CLARIN LRU allowances.")
                 return allowances
-            _logger.warning("No CLARIN LRU allowances found.")
         except Exception as e:
             _logger.error(f"Error fetching CLARIN LRU allowances [{url}]: {e}")
         return None
@@ -1215,9 +1213,7 @@ class DSpaceClient:
             data = parse_json(response)
             allowances = data.get('_embedded', {}).get('clarinlruallowances')
             if allowances:
-                _logger.info(f"Found {len(allowances)} user allowance(s).")
                 return allowances
-            _logger.warning(f"No user allowances found for user: {user_uuid} and bitstream: {bitstream_uuid}")
         except Exception as e:
             _logger.error(f"Error fetching user allowances: {e}")
         return None
@@ -1236,9 +1232,7 @@ class DSpaceClient:
         try:
             response = self.api_post(url, json=metadata_payload, params=params)
             if response.status_code == 200:
-                _logger.info(f"User metadata access managed for bitstream: {bitstream_uuid}")
                 return True
-            _logger.warning(f"Failed to manage user metadata: {response.status_code}")
         except Exception as e:
             _logger.error(f"Error managing user metadata: {e}")
         return False
@@ -1253,7 +1247,6 @@ class DSpaceClient:
         try:
             response = self.api_get(url, params=params)
             user_data = parse_json(response)
-            _logger.info(f"User fetched by email: {email}")
             return User(user_data)
         except Exception as e:
             _logger.error(f"Error retrieving user by email {email}: {e}")

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -704,7 +704,6 @@ class DSpaceClient:
             logging.error(f'Error creating bitstream: {r.status_code}: {r.text}')
             return None
 
-
     def download_bitstream(self, uuid=None):
         """
         Download bitstream and return full response object including headers, and content

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1201,7 +1201,7 @@ class DSpaceClient:
             logging.error(f"Error fetching CLARIN LRU allowances [{url}]: {e}")
         return None
 
-    def get_clarinlruallowances_by_bitstreama_and_user(self, bitstream_uuid, user_uuid):
+    def get_clarinlruallowances_by_bitstream_and_user(self, bitstream_uuid, user_uuid):
         """
         Fetch user allowances for a specific bitstream and user.
         """
@@ -1260,7 +1260,7 @@ class DSpaceClient:
 
     def get_http_status(self, url):
         """
-        Check the HTTP status code of a URL.
+        Get the HTTP status code of a URL.
         """
         if not url:
             logging.warning("Provided URL is not defined.")
@@ -1274,9 +1274,9 @@ class DSpaceClient:
             return None
 
 
-    def fetch_bundle(self, bundle_reference):
+    def get_bundle(self, bundle_reference):
         """
-        Fetch a bundle either by UUID or URL.
+        Get a bundle either by UUID or URL.
         """
         if not bundle_reference:
             logging.warning("No bundle reference provided.")
@@ -1287,16 +1287,17 @@ class DSpaceClient:
         try:
             response = self.api_get(url)
             data = parse_json(response)
-            bundle = data.get('_embedded', {}).get('bundles', [{}])[0]
+            bundles = data.get('_embedded', {}).get('bundles', [])
+            bundle = bundles[0] if bundles else {}
             logging.info(f"Bundle retrieved: {bundle.get('uuid', 'unknown')}")
             return bundle
         except Exception as e:
-            logging.error(f"Error fetching bundle: {e}")
+            logging.error(f"Error getting bundle: {e}")
             return None
 
-    def fetch_bitstreams(self, bitstream_reference):
+    def get_bitstream(self, bitstream_reference):
         """
-        Fetch bitstreams either by UUID or direct URL.
+        Get bitstream either by UUID or direct URL.
         """
         if not bitstream_reference:
             logging.warning("No bitstream reference provided.")
@@ -1308,10 +1309,11 @@ class DSpaceClient:
             response = self.api_get(url)
             data = parse_json(response)
             bitstreams = data.get('_embedded', {}).get('bitstreams', [])
-            logging.info(f"Fetched {len(bitstreams)} bitstream(s).")
-            return bitstreams
+            bitstream = bitstreams[0] if bitstreams else {}
+            logging.info(f"Bitstream retrieved: {bitstream.get('uuid', 'unknown')}")
+            return bitstream
         except Exception as e:
-            logging.error(f"Error fetching bitstreams: {e}")
+            logging.error(f"Error getting bitstream: {e}")
             return None
 
 

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1111,7 +1111,7 @@ class DSpaceClient:
             _logger.error("Provided 'eperson' is not an instance of User.")
             return False
 
-        url = f' {self.API_ENDPOINT}/eperson/groups/{group.uuid}/epersons'
+        url = f'{self.API_ENDPOINT}/eperson/groups/{group.uuid}/epersons'
         eperson_uri = f'{self.API_ENDPOINT}/epersons/{eperson.uuid}'
         r = self.api_post_uri(url, params=None, uri_list=eperson_uri)
         if r.status_code == 204:

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1082,6 +1082,16 @@ class DSpaceClient:
             # that you see for other DSO types - still figuring out the best way
         return Group(api_resource=parse_json(self.create_dso(url, params=None, data=data)))
 
+    def create_submit_group(self, collection):
+        """
+        Creates a submitter group for the given collection.
+        """
+        url = f'{self.API_ENDPOINT}/core/collections/{collection.uuid}/submittersGroup'
+        r = self.api_post(url, json={}, params=None)
+        if r.status_code == 201:
+            return Group(parse_json(r))
+        return None
+
     def add_member(self, group, eperson):
         """
         Adds a user (EPerson) as a member of the specified group.
@@ -1206,6 +1216,23 @@ class DSpaceClient:
         if '_embedded' in r_json:
             if 'resourcepolicies' in r_json['_embedded']:
                 return r_json['_embedded']['resourcepolicies'][0]
+
+    def create_resource_policy(self, resource_uuid, data, group_uuid=None, eperson_uuid=None):
+        """
+        Creates a resource policy by sending a POST request to the API endpoint.
+        """
+        url = f'{self.API_ENDPOINT}/authz/resourcepolicies'
+        params = {"resource": resource_uuid}
+        if group_uuid:
+            params["group"] = group_uuid
+        if eperson_uuid:
+            params["eperson"] = eperson_uuid
+
+        r = self.api_post(url, params=params, json=data)
+        if r.status_code == 201:
+            return True
+        return False
+
 
     def update_resource_policy_group(self, policy_id, group_uuid):
         """

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -947,6 +947,26 @@ class DSpaceClient:
 
         return dso_type(api_resource=parse_json(r))
 
+    def remove_metadata(self, dso, field, place):
+        """
+        Remove metadata from dso based on metadata field.
+        """
+        if dso is None or field is None or place is None or not isinstance(dso, DSpaceObject):
+            # TODO: separate these tests, and add better error handling
+            logging.error('Invalid or missing DSpace object, field or value string')
+            return self
+        dso_type = type(dso)
+
+        # Place can be 0+ integer, or a hyphen - meaning "last"
+        path = f'/metadata/{field}/{place}'
+
+        url = dso.links['self']['href']
+
+        r = self.api_patch(
+            url=url, operation=self.PatchOperation.REMOVE, path=path, value=None)
+
+        return dso_type(api_resource=parse_json(r))
+
     def create_user(self, user, token=None):
         """
         Create a user

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1082,6 +1082,35 @@ class DSpaceClient:
             # that you see for other DSO types - still figuring out the best way
         return Group(api_resource=parse_json(self.create_dso(url, params=None, data=data)))
 
+    def add_member(self, group, eperson):
+        """
+        Adds a user (EPerson) as a member of the specified group.
+
+        Args:
+            group (Group): The group to which the user will be added.
+            eperson (User): The EPerson to be added as a member of the group.
+
+        Returns:
+            bool: True if the user was successfully added (HTTP 204), False otherwise.
+        """
+        if not isinstance(group, Group):
+            _logger.error("Provided 'group' is not an instance of Group.")
+            return False
+
+        if not isinstance(eperson, User):
+            _logger.error("Provided 'eperson' is not an instance of User.")
+            return False
+
+        url = f' {self.API_ENDPOINT}/eperson/groups/{group.uuid}/epersons'
+        eperson_uri = f'{self.API_ENDPOINT}/epersons/{eperson.uuid}'
+        r = self.api_post_uri(url, params=None, uri_list=eperson_uri)
+        if r.status_code == 204:
+            return True
+        _logger.error(f"Failed to add user {eperson.uuid} to group {group.uuid}. "
+                        f"Status code: {r.status_code}")
+        return False
+
+
     def start_workflow(self, workspace_item):
         url = f'{self.API_ENDPOINT}/workflow/workflowitems'
         res = parse_json(self.api_post_uri(url, params=None, uri_list=workspace_item))

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1261,8 +1261,12 @@ class DSpaceClient:
     def get_clarinlruallowances_by_bitstream_and_user(self, bitstream_uuid, user_uuid):
         """
         Fetch user allowances for a specific bitstream and user.
+
+        Note: the collection name must be plural. DSpace 9 routes REST repositories by their
+        declared plural name, so the singular form returns 404 "The repository type
+        core.clarinlruallowance was not found". The plural form works on DSpace 7 too.
         """
-        url = f'{self.API_ENDPOINT}/core/clarinlruallowance/search/byBitstreamAndUser'
+        url = f'{self.API_ENDPOINT}/core/clarinlruallowances/search/byBitstreamAndUser'
         params = {'bitstreamUUID': bitstream_uuid, 'userUUID': user_uuid}
         try:
             response = self.api_get(url, params=params)

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1261,10 +1261,6 @@ class DSpaceClient:
     def get_clarinlruallowances_by_bitstream_and_user(self, bitstream_uuid, user_uuid):
         """
         Fetch user allowances for a specific bitstream and user.
-
-        Note: the collection name must be plural. DSpace 9 routes REST repositories by their
-        declared plural name, so the singular form returns 404 "The repository type
-        core.clarinlruallowance was not found". The plural form works on DSpace 7 too.
         """
         url = f'{self.API_ENDPOINT}/core/clarinlruallowances/search/byBitstreamAndUser'
         params = {'bitstreamUUID': bitstream_uuid, 'userUUID': user_uuid}

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -517,34 +517,6 @@ class RelationshipType(AddressableHALResource):
     def __init__(self, api_resource):
         super(RelationshipType, self).__init__(api_resource)
 
-    def get_metadata_values(self, field):
-        """
-        Return metadata values as simple list of strings
-        @param field: DSpace field, eg. dc.creator
-        @return: list of strings
-        """
-        values = list()
-        if field in self.metadata:
-            values = self.metadata[field]
-        return values
-
-    def as_dict(self):
-        """
-        Return a dict representation of this Item, based on super with item-specific attributes added
-        @return: dict of Item for API use
-        """
-        dso_dict = super(Item, self).as_dict()
-        item_dict = {'inArchive': self.inArchive, 'discoverable': self.discoverable, 'withdrawn': self.withdrawn}
-        return {**dso_dict, **item_dict}
-
-    @classmethod
-    def from_dso(cls, dso: DSpaceObject):
-        # Create new Item and copy everything over from this dso
-        item = cls()
-        for key, value in dso.__dict__.items():
-            item.__dict__[key] = value
-        return item
-
 class License(AddressableHALResource):
     """
     Specific attributes and functions for licenses

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -528,8 +528,11 @@ class License(AddressableHALResource):
         self.definition = (api_resource or {}).get('definition')
         self.confirmation = (api_resource or {}).get('confirmation', 0)
         self.requiredInfo = (api_resource or {}).get('requiredInfo')
-        self.licenseLabel = Label((api_resource or {}).get('clarinLicenseLabel'))
-        self.extendedLicenseLabel = [Label(label) for label in (api_resource or {}).get('extendedClarinLicenseLabels', [])]
+        self.licenseLabel = Label(license_label_value) \
+            if (license_label_value := (api_resource or {}).get('clarinLicenseLabel')) \
+            else None
+        self.extendedLicenseLabel = [Label(label) for label in
+                                     (api_resource or {}).get('extendedClarinLicenseLabels', [])]
         self.bitstream = (api_resource or {}).get('bitstreams')
 
     def to_dict(self):

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -523,17 +523,17 @@ class License(AddressableHALResource):
     """
     def __init__(self, api_resource=None):
         super(License, self).__init__(api_resource)
+        api_resource = api_resource or {}
         self.type = 'clarinlicense'
-        self.name = (api_resource or {}).get('name')
-        self.definition = (api_resource or {}).get('definition')
-        self.confirmation = (api_resource or {}).get('confirmation', 0)
-        self.requiredInfo = (api_resource or {}).get('requiredInfo')
-        self.licenseLabel = Label(license_label_value) \
-            if (license_label_value := (api_resource or {}).get('clarinLicenseLabel')) \
-            else None
+        self.name = api_resource.get('name')
+        self.definition = api_resource.get('definition')
+        self.confirmation = api_resource.get('confirmation', 0)
+        self.requiredInfo = api_resource.get('requiredInfo')
+        license_label_value = api_resource.get('clarinLicenseLabel')
+        self.licenseLabel = Label(license_label_value) if license_label_value else None
         self.extendedLicenseLabel = [Label(label) for label in
-                                     (api_resource or {}).get('extendedClarinLicenseLabels', [])]
-        self.bitstream = (api_resource or {}).get('bitstreams')
+                                     api_resource.get('extendedClarinLicenseLabels', [])]
+        self.bitstream = api_resource.get('bitstreams')
 
     def to_dict(self):
         return {
@@ -556,11 +556,12 @@ class Label(AddressableHALResource):
         @param api_resource: API result object to use as initial data
         """
         super(Label, self).__init__(api_resource)
+        api_resource = api_resource or {}
         self.type = 'clarinlicenselabel'
-        self.label = (api_resource or {}).get('label')
-        self.title = (api_resource or {}).get('title')
-        self.icon = (api_resource or {}).get('icon')
-        self.extended = (api_resource or {}).get('extended', False)
+        self.label = api_resource.get('label')
+        self.title = api_resource.get('title')
+        self.icon = api_resource.get('icon')
+        self.extended = api_resource.get('extended', False)
 
     def to_dict(self):
         return {

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -524,14 +524,13 @@ class License(AddressableHALResource):
     def __init__(self, api_resource=None):
         super(License, self).__init__(api_resource)
         self.type = 'clarinlicense'
-        if api_resource:
-            self.name = api_resource.get('name')
-            self.definition = api_resource.get('definition')
-            self.confirmation = api_resource.get('confirmation', 0)
-            self.requiredInfo = api_resource.get('requiredInfo')
-            self.licenseLabel = Label(api_resource.get('clarinLicenseLabel'))
-            self.extendedLicenseLabel = [Label(label) for label in api_resource.get('extendedClarinLicenseLabels', [])]
-            self.bitstream = api_resource.get('bitstreams')
+        self.name = (api_resource or {}).get('name')
+        self.definition = (api_resource or {}).get('definition')
+        self.confirmation = (api_resource or {}).get('confirmation', 0)
+        self.requiredInfo = (api_resource or {}).get('requiredInfo')
+        self.licenseLabel = Label((api_resource or {}).get('clarinLicenseLabel'))
+        self.extendedLicenseLabel = [Label(label) for label in (api_resource or {}).get('extendedClarinLicenseLabels', [])]
+        self.bitstream = (api_resource or {}).get('bitstreams')
 
     def to_dict(self):
         return {
@@ -555,11 +554,10 @@ class Label(AddressableHALResource):
         """
         super(Label, self).__init__(api_resource)
         self.type = 'clarinlicenselabel'
-        if api_resource:
-            self.label = api_resource.get('label')
-            self.title = api_resource.get('title')
-            self.icon = api_resource.get('icon')
-            self.extended = api_resource.get('extended', False)
+        self.label = (api_resource or {}).get('label')
+        self.title = (api_resource or {}).get('title')
+        self.icon = (api_resource or {}).get('icon')
+        self.extended = (api_resource or {}).get('extended', False)
 
     def to_dict(self):
         return {

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -521,27 +521,17 @@ class License(AddressableHALResource):
     """
     Specific attributes and functions for licenses
     """
-    type = 'clarinlicense'
-    name = None
-    definition = None
-    confirmation = 0
-    requiredInfo = None
-    licenseLabel = None
-    extendedLicenseLabel = []
-    bitstream = None
-
     def __init__(self, api_resource=None):
         super(License, self).__init__(api_resource)
-
-        if api_resource is not None:
-            self.type = 'clarinlicense'
-            self.name = api_resource['name'] if 'name' in api_resource else None
-            self.definition = api_resource['definition'] if 'definition' in api_resource else None
-            self.confirmation = api_resource['confirmation'] if 'confirmation' in api_resource else 0
-            self.requiredInfo = api_resource['requiredInfo'] if 'requiredInfo' in api_resource else None
-            self.licenseLabel = Label(api_resource['clarinLicenseLabel']) if 'clarinLicenseLabel' in api_resource else None
+        self.type = 'clarinlicense'
+        if api_resource:
+            self.name = api_resource.get('name')
+            self.definition = api_resource.get('definition')
+            self.confirmation = api_resource.get('confirmation', 0)
+            self.requiredInfo = api_resource.get('requiredInfo')
+            self.licenseLabel = Label(api_resource.get('clarinLicenseLabel'))
             self.extendedLicenseLabel = [Label(label) for label in api_resource.get('extendedClarinLicenseLabels', [])]
-            self.bitstream = api_resource['bitstreams'] if 'bitstreams' in api_resource else None
+            self.bitstream = api_resource.get('bitstreams')
 
     def to_dict(self):
         return {
@@ -558,25 +548,18 @@ class Label(AddressableHALResource):
     """
     Specific attributes and functions for licenses
     """
-    type = 'clarinlabel'
-    label = None
-    title = None
-    icon = None
-    extended = False
-
     def __init__(self, api_resource=None):
         """
         Default constructor. Call DSpaceObject init then set label-specific attributes
         @param api_resource: API result object to use as initial data
         """
         super(Label, self).__init__(api_resource)
-
-        if api_resource is not None:
-            self.type = 'clarinlicenselabel'
-            self.label = api_resource['label'] if 'label' in api_resource else None
-            self.title = api_resource['title'] if 'title' in api_resource else None
-            self.icon = api_resource['icon'] if 'icon' in api_resource else None
-            self.extended = api_resource['extended'] if 'extended' in api_resource else None
+        self.type = 'clarinlicenselabel'
+        if api_resource:
+            self.label = api_resource.get('label')
+            self.title = api_resource.get('title')
+            self.icon = api_resource.get('icon')
+            self.extended = api_resource.get('extended', False)
 
     def to_dict(self):
         return {


### PR DESCRIPTION
## Why

`dataquest-dev/dspace-rest-python` has three long-lived branches with **no ancestry between any of them**. `dtq` is the branch the `DSpace-ISSTAG-Integration` family consumes as a submodule, so it needs the useful work from the other lanes.

| Branch | Role | Tip | vs `main` |
|---|---|---|---|
| `main` | CLARIN/UFAL lane — License/Label models, `clarinlruallowances`, submit-group, eperson-to-group | `dbec151` 2026-08-11 | — |
| `dtq` | dataquest STAG lane — ResourcePolicy model + API, reauth, timeouts, proxy, logging, 404-safe bundles | `f9ca942` 2026-08-17 | 25 ahead / 31 behind |
| `dtq-dev` | **not a library branch** — see below | `145635a` 2023-06-12 | 1 ahead / 64 behind |

Merge base of `main` and `dtq` is `5724696` ("merged", 2024-10-24). Since then `main` added **+300/−0** lines and `dtq` **+263/−71**, both confined to `dspace_rest_client/client.py` and `dspace_rest_client/models.py`. No build files, deps or layout diverged.

## What this PR does

Merges `origin/main` into `dtq` via `merge/main-into-dtq`. `dtq` gains main's CLARIN surface; nothing of dtq's hardening is lost.

**Gained from `main`** (13 new methods + 2 new models): `get_clarinlruallowances`, `get_clarinlruallowances_by_bitstream_and_user`, `create_clarinlruallowances`, `create_submit_group`, `add_member`, `get_user_by_email`, `get_bundle_by_name`, `get_items_from_collection`, `get_item_by_handle`, `api_put_uri`, `get_resource_policy`, `create_resource_policy`, `update_resource_policy_group`, plus the `License` and `Label` models.

**Kept from `dtq`**: reauth on 401, request timeouts, proxy support, `verify_response`, `_last_err`, `ResourcePolicy` model, `get_resourcepolicy`/`create_resourcepolicy`, `get_owningCollection`, 404-safe bundles.

## Conflict resolutions

3 hunks — 2 in `client.py`, 1 in `models.py`.

### 1. `get_items` — signature clash (breaking if resolved wrong)

- `dtq`: `get_items(self, page=0, size=20)` — sends `page`/`size` params.
- `main`: `get_items(self)` — **and `main` still carried two duplicate `def get_items` definitions**. The shadowing second one tested for `'collections'` in `_embedded` while iterating `_embedded['items']`.

**Resolved:** kept dtq's paginated version, dropped both of main's. `DSpace-ISstag-integration/src/ingest/_dspace.py` calls `get_items(page=page, size=page_size)`, so main's signature would break the STAG import loop. `dspace-rest-test` calls `get_items()` with no args — satisfied by the defaults. main's additive `get_item_by_handle` is kept alongside.

### 2. `remove_metadata` — signature clash (breaking if resolved wrong)

- `dtq`: `remove_metadata(self, dso, field)` → `PATCH /metadata/{field}` (removes all values).
- `main`: `remove_metadata(self, dso, field, place)` → `PATCH /metadata/{field}/{place}` (removes one value); also regressed to module-level `logging.error`.

**Resolved** to a compatible superset:

```python
def remove_metadata(self, dso, field, place=None):
    ...
    path = f'/metadata/{field}' if place is None else f'/metadata/{field}/{place}'
```

Both dtq's 2-arg call sites and `dspace-import-clarin`'s `remove_metadata(item, key, 0)` keep working. `_logger` restored.

### 3. `models.py` — positional conflict

Both sides appended at EOF. **Resolved** by keeping all three: `License` (with `to_dict`), `Label` (with `to_dict`), `ResourcePolicy` (with `as_dict` and `__repr__`). Trailing newline added.

## One extra change beyond conflict resolution

`api_put_uri` was written on `main` against the pre-hardening base, so the merge would have imported it without any of dtq's conventions. Harmonised with its sibling `api_put`: resets `self._last_err` on entry, passes `proxies=self.proxies`, and uses `_logger` instead of module-level `logging`. **Public signature unchanged** — `dspace-rest-test` uses it in 3 places.

All of main's other new methods go through `self.api_get`/`self.api_post`, so they inherit dtq's hardening for free.

## Why `dtq-dev` is NOT merged

Its only unique commit — `145635a` (2023-06-12, "copied code from dtq main") — is a snapshot of a *different project*, the DSpace import/migration tool. It:

- **moves** `dspace_rest_client/{client,models}.py` → `support/dspace_interface/`
- **deletes** `setup.py`, `example.py`, `example_gets.py`, `solr_example.py`, `publish.sh`, `CHANGELOG.md`, `MAINTAINING.md`
- **adds** ~8.5k lines of import tooling, test fixtures, license icon PNGs and a localization CSV

Merging it would destroy the installable package and contributes zero library value. It is 1 ahead / 64 behind `main` and an ancestor of nothing.

## Both resource-policy APIs retained

`main` and `dtq` independently grew policy APIs with different names and different return shapes, and **both have live consumers** (`dspace-import-clarin` uses main's dict-based set; all five `DSpace-ISstag-integration*` clones use dtq's model-based set). They occupy different regions of `client.py`, so git merged both cleanly. Unification is deliberately left to a separate deprecation change.

## Verification

- `python -m compileall -q dspace_rest_client` — clean
- package imports (`DSpaceClient`, `Label`, `License`, `ResourcePolicy`, `Item`, `Bundle`, `Bitstream`, `Community`, `Collection`) — OK
- **no duplicate method definitions** in `client.py` (`uniq -d` empty); no duplicate class names in `models.py`
- **API surface is exactly the union** of both branches — nothing lost from either side apart from main's duplicate `get_items`
- runtime signature checks: `get_items(self, page=0, size=20)`, `remove_metadata(self, dso, field, place=None)`, `api_put_uri(self, url, params, uri_list, retry=False)`
- model round-trips exercised: `Label.to_dict()`, `License.to_dict()` (including nested `clarinLicenseLabel`), `ResourcePolicy.as_dict()`/`__repr__()` (including `_embedded.group` extraction)
- **`DSpace-ISstag-integration` suite: identical result with and without this merge — 579 passed, 40 failed.** The 40 failures are pre-existing, all in `tests/test_app_security.py`, caused by `flask` being absent from that environment (`ModuleNotFoundError: No module named 'flask'` at `www-stats/web/be/app.py:37`), not by the library.
- CLARIN consumer call sites in `dspace-import-clarin` and `dspace-rest-test` checked statically against the merged signatures.

No live-backend smoke test was run — worth doing against a dev DSpace before the submodule pins are bumped.

## Follow-ups (not in this PR)

1. **Fix the submodule tracking branch.** All five `DSpace-ISstag-integration*` clones declare `branch = dtq-dev` in `.gitmodules` while pinning a commit on `dtq`. `git submodule update --remote` would regress them to 2023 code. Should be `branch = dtq`.
2. **Bump the submodule pins** from `e1c05a99` (2026-02-23) to the post-merge `dtq` tip — also picks up `51b65fe` (timeout), `db03111` (robust check), `f9ca942` (404-safe bundles).
3. **Retire `dtq-dev`** — archive as a tag, then delete the branch.
4. **Deprecate the duplicate resource-policy API** — mark main's dict-based trio legacy, migrate `dspace-import-clarin` to the `ResourcePolicy` model, then remove.
5. **Two branches merged nowhere** — `added-post-with-text` (2025-07-04) and `feature/upstream-pagination-and-new-features` (2026-02-13, "upstream pagination, iterators, embeds, and new API methods"). Triage separately.
6. **Upstream drift** — the fork is 137 commits behind `the-library-code/dspace-rest-python` (v0.1.20). Separate project.
7. **Add minimal CI** — a compile + import + duplicate-def job would have caught main's shadowed `get_items` years ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
